### PR TITLE
Use MudBlazor theme for styling

### DIFF
--- a/BlazorApp1/Components/App.razor
+++ b/BlazorApp1/Components/App.razor
@@ -13,12 +13,35 @@
 </head>
 
 <body>
-    <MudThemeProvider />
-    <MudDialogProvider />
-    <MudSnackbarProvider />
-    <Routes />
+    <MudThemeProvider Theme="@_theme">
+        <MudThemeManager />
+        <MudDialogProvider />
+        <MudSnackbarProvider />
+        <Routes />
+    </MudThemeProvider>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 
 </html>
+
+@code {
+    private readonly MudTheme _theme = new()
+    {
+        Palette = new Palette
+        {
+            Primary = "#1b6ec2"
+        },
+        PaletteDark = new PaletteDark
+        {
+            Primary = "#1b6ec2"
+        },
+        Typography = new Typography
+        {
+            Default = new Default
+            {
+                FontSize = "16px"
+            }
+        }
+    };
+}


### PR DESCRIPTION
## Summary
- Remove custom stylesheet in favor of MudBlazor theming
- Configure MudTheme with primary color and font size
- Add MudThemeManager for built-in light/dark mode toggling

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b849a94e78832d8f65cfa7e57ecdd0